### PR TITLE
Merge Secret Keeper chaincode implementation.

### DIFF
--- a/samples/chaincode/secret-keeper-go/.gitignore
+++ b/samples/chaincode/secret-keeper-go/.gitignore
@@ -1,0 +1,7 @@
+ecc
+ecc-bundle
+enclave.json
+private.pem
+public.pem
+mrenclave
+details.env

--- a/samples/chaincode/secret-keeper-go/Makefile
+++ b/samples/chaincode/secret-keeper-go/Makefile
@@ -1,0 +1,9 @@
+# Copyright 2019 Intel Corporation
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TOP = ../../..
+include $(TOP)/ecc_go/build.mk
+
+CC_NAME ?= fpc-secret-keeper-go

--- a/samples/chaincode/secret-keeper-go/chaincode/secret-keeper.go
+++ b/samples/chaincode/secret-keeper-go/chaincode/secret-keeper.go
@@ -29,8 +29,7 @@ type Secret struct {
 	Value string `json:Value`
 }
 
-func (t *SecretKeeper) InitLedger(ctx contractapi.TransactionContextInterface) error {
-
+func (t *SecretKeeper) InitSecretKeeper(ctx contractapi.TransactionContextInterface) error {
 	// init authSet
 	pubkeyset := make(map[string]struct{})
 	pubkeyset["Alice"] = struct{}{}
@@ -51,7 +50,7 @@ func (t *SecretKeeper) InitLedger(ctx contractapi.TransactionContextInterface) e
 
 	// init secret
 	secret := Secret{
-		Value: "",
+		Value: "DefaultSecret",
 	}
 
 	secretJson, err := json.Marshal(secret)
@@ -133,7 +132,7 @@ func (t *SecretKeeper) LockSecret(ctx contractapi.TransactionContextInterface, s
 
 	// update the value
 	newSecret := Secret{
-		Value: "",
+		Value: value,
 	}
 
 	newSecretJson, err := json.Marshal(newSecret)
@@ -168,7 +167,7 @@ func (t *SecretKeeper) RevealSecret(ctx contractapi.TransactionContextInterface,
 		return nil, fmt.Errorf("the asset %s does not exist", SECRET_KEY)
 	}
 	var secret Secret
-	err = json.Unmarshal(secretJson, secret)
+	err = json.Unmarshal(secretJson, &secret)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +184,7 @@ func GetAuthList(ctx contractapi.TransactionContextInterface) (*AuthSet, error) 
 	}
 
 	var authSet AuthSet
-	err = json.Unmarshal(authSetJson, authSet)
+	err = json.Unmarshal(authSetJson, &authSet)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +197,7 @@ func VerifySig(ctx contractapi.TransactionContextInterface, sig string) (bool, e
 		return false, err
 	}
 
-	if _, exist := authSet.Pubkey["sig"]; exist {
+	if _, exist := authSet.Pubkey[sig]; exist {
 		return true, nil
 	}
 

--- a/samples/chaincode/secret-keeper-go/chaincode/secret-keeper.go
+++ b/samples/chaincode/secret-keeper-go/chaincode/secret-keeper.go
@@ -1,0 +1,206 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+)
+
+const OK = "OK"
+const AUTH_LIST_KEY = "AUTH_LIST_KEY"
+const SECRET_KEY = "SECRET_KEY"
+
+type SecretKeeper struct {
+	contractapi.Contract
+}
+
+type AuthSet struct {
+	Pubkey map[string]struct{}
+}
+
+type Secret struct {
+	Value string `json:Value`
+}
+
+func (t *SecretKeeper) InitLedger(ctx contractapi.TransactionContextInterface) error {
+
+	// init authSet
+	pubkeyset := make(map[string]struct{})
+	pubkeyset["Alice"] = struct{}{}
+	pubkeyset["Bob"] = struct{}{}
+	authSet := AuthSet{
+		Pubkey: pubkeyset,
+	}
+
+	authSetJson, err := json.Marshal(authSet)
+	if err != nil {
+		return err
+	}
+
+	err = ctx.GetStub().PutState(AUTH_LIST_KEY, authSetJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", AUTH_LIST_KEY, err)
+	}
+
+	// init secret
+	secret := Secret{
+		Value: "",
+	}
+
+	secretJson, err := json.Marshal(secret)
+	if err != nil {
+		return err
+	}
+
+	err = ctx.GetStub().PutState(SECRET_KEY, secretJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", SECRET_KEY, err)
+	}
+
+	return nil
+}
+
+func (t *SecretKeeper) AddUser(ctx contractapi.TransactionContextInterface, sig string, pubkey string) error {
+	// check if the user allow to update authSet
+	valid, err := VerifySig(ctx, sig)
+	if err != nil {
+		return err
+	}
+	if valid != true {
+		return fmt.Errorf("User are not allowed to perform this action.")
+	}
+
+	// update the value
+	authSet, err := GetAuthList(ctx)
+	authSet.Pubkey[pubkey] = struct{}{}
+
+	authSetJson, err := json.Marshal(authSet)
+	if err != nil {
+		return err
+	}
+
+	err = ctx.GetStub().PutState(AUTH_LIST_KEY, authSetJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", AUTH_LIST_KEY, err)
+	}
+
+	return nil
+}
+
+func (t *SecretKeeper) RemoveUser(ctx contractapi.TransactionContextInterface, sig string, pubkey string) error {
+	// check if the user allow to update authSet
+	valid, err := VerifySig(ctx, sig)
+	if err != nil {
+		return err
+	}
+	if valid != true {
+		return fmt.Errorf("User are not allowed to perform this action.")
+	}
+
+	// update the value
+	authSet, err := GetAuthList(ctx)
+	delete(authSet.Pubkey, pubkey)
+
+	authSetJson, err := json.Marshal(authSet)
+	if err != nil {
+		return err
+	}
+
+	err = ctx.GetStub().PutState(AUTH_LIST_KEY, authSetJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", AUTH_LIST_KEY, err)
+	}
+
+	return nil
+}
+
+func (t *SecretKeeper) LockSecret(ctx contractapi.TransactionContextInterface, sig string, value string) error {
+	// check if the user allow to update secret
+	valid, err := VerifySig(ctx, sig)
+	if err != nil {
+		return err
+	}
+	if valid != true {
+		return fmt.Errorf("User are not allowed to perform this action.")
+	}
+
+	// update the value
+	newSecret := Secret{
+		Value: "",
+	}
+
+	newSecretJson, err := json.Marshal(newSecret)
+	if err != nil {
+		return err
+	}
+
+	err = ctx.GetStub().PutState(SECRET_KEY, newSecretJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", SECRET_KEY, err)
+	}
+
+	return nil
+}
+
+func (t *SecretKeeper) RevealSecret(ctx contractapi.TransactionContextInterface, sig string) (*Secret, error) {
+	// check if the user allow to view the secret.
+	valid, err := VerifySig(ctx, sig)
+	if err != nil {
+		return nil, err
+	}
+	if valid != true {
+		return nil, fmt.Errorf("User are not allowed to perform this action.")
+	}
+
+	// reveal secret
+	secretJson, err := ctx.GetStub().GetState(SECRET_KEY)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from world state: %v", err)
+	}
+	if secretJson == nil {
+		return nil, fmt.Errorf("the asset %s does not exist", SECRET_KEY)
+	}
+	var secret Secret
+	err = json.Unmarshal(secretJson, secret)
+	if err != nil {
+		return nil, err
+	}
+	return &secret, nil
+}
+
+func GetAuthList(ctx contractapi.TransactionContextInterface) (*AuthSet, error) {
+	authSetJson, err := ctx.GetStub().GetState(AUTH_LIST_KEY)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from world state: %v", err)
+	}
+	if authSetJson == nil {
+		return nil, fmt.Errorf("the asset %s does not exist", AUTH_LIST_KEY)
+	}
+
+	var authSet AuthSet
+	err = json.Unmarshal(authSetJson, authSet)
+	if err != nil {
+		return nil, err
+	}
+	return &authSet, nil
+}
+
+func VerifySig(ctx contractapi.TransactionContextInterface, sig string) (bool, error) {
+	authSet, err := GetAuthList(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if _, exist := authSet.Pubkey["sig"]; exist {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/samples/chaincode/secret-keeper-go/chaincode/secret-keeper_test.go
+++ b/samples/chaincode/secret-keeper-go/chaincode/secret-keeper_test.go
@@ -1,0 +1,272 @@
+package chaincode
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hyperledger/fabric-private-chaincode/ercc/registry/fakes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrongSignature(t *testing.T) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeper(transactionContext)
+	require.NoError(t, err)
+
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(0)
+
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	falseSig := "falseSignature"
+	fakeSecret := "fakeSecret"
+	err = secretKeeper.AddUser(transactionContext, falseSig, falseSig)
+	require.EqualError(t, err, "User are not allowed to perform this action.")
+
+	err = secretKeeper.RemoveUser(transactionContext, falseSig, falseSig)
+	require.EqualError(t, err, "User are not allowed to perform this action.")
+
+	err = secretKeeper.LockSecret(transactionContext, falseSig, fakeSecret)
+	require.EqualError(t, err, "User are not allowed to perform this action.")
+
+	secret, err := secretKeeper.RevealSecret(transactionContext, falseSig)
+	require.EqualError(t, err, "User are not allowed to perform this action.")
+	require.Nil(t, secret)
+}
+
+func TestAddUserFlow(t *testing.T) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeper(transactionContext)
+	require.NoError(t, err)
+
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(0)
+	_, _ = chaincodeStub.PutStateArgsForCall(1) // get default secret
+
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	aliceSig := "Alice"
+	evePubKey := "Eve"
+
+	// check if authlist not contains eve
+	var authSet AuthSet
+	err = json.Unmarshal(authSetByte, &authSet)
+	require.NoError(t, err)
+	_, exist := authSet.Pubkey[evePubKey]
+	require.False(t, exist)
+
+	err = secretKeeper.AddUser(transactionContext, aliceSig, evePubKey)
+	require.NoError(t, err)
+
+	// check if authlist contains eve.
+	_, authSetByte2 := chaincodeStub.PutStateArgsForCall(2)
+	var authSet2 AuthSet
+	err = json.Unmarshal(authSetByte2, &authSet2)
+	require.NoError(t, err)
+	_, exist = authSet2.Pubkey[evePubKey]
+	require.True(t, exist)
+}
+
+func TestRemoveUser(t *testing.T) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeper(transactionContext)
+	require.NoError(t, err)
+
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(0)
+	_, _ = chaincodeStub.PutStateArgsForCall(1) // get default secret
+
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	aliceSig := "Alice"
+	bobPubKey := "Bob"
+
+	// check if authlist contains bob.
+	var authSet AuthSet
+	err = json.Unmarshal(authSetByte, &authSet)
+	require.NoError(t, err)
+	_, exist := authSet.Pubkey[bobPubKey]
+	require.True(t, exist)
+
+	err = secretKeeper.RemoveUser(transactionContext, aliceSig, bobPubKey)
+	require.NoError(t, err)
+
+	// check if authlist doesn't contain bob anymore.
+	_, authSetByte2 := chaincodeStub.PutStateArgsForCall(2)
+	var authSet2 AuthSet
+	err = json.Unmarshal(authSetByte2, &authSet2)
+	require.NoError(t, err)
+	_, exist = authSet2.Pubkey[bobPubKey]
+	require.False(t, exist)
+}
+
+func TestLockSecret(t *testing.T) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeper(transactionContext)
+	require.NoError(t, err)
+
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(0)
+	_, _ = chaincodeStub.PutStateArgsForCall(1) // get default secret
+
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	aliceSig := "Alice"
+	newSecret := "newSecret"
+
+	err = secretKeeper.LockSecret(transactionContext, aliceSig, newSecret)
+	require.NoError(t, err)
+
+	// check secret key value.
+	_, secretByte := chaincodeStub.PutStateArgsForCall(2)
+	var secret Secret
+	err = json.Unmarshal(secretByte, &secret)
+	require.NoError(t, err)
+	require.EqualValues(t, secret.Value, newSecret)
+}
+
+func TestRevealSecret(t *testing.T) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeper(transactionContext)
+	require.NoError(t, err)
+
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(0)
+	_, defaultSecretByte := chaincodeStub.PutStateArgsForCall(1)
+
+	aliceSig := "Alice"
+	var defaultSecret Secret
+	err = json.Unmarshal(defaultSecretByte, &defaultSecret)
+	require.NoError(t, err)
+
+	// check the return value equal with the secret in test.
+	chaincodeStub.GetStateReturnsOnCall(0, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(1, defaultSecretByte, nil)
+	secret, err := secretKeeper.RevealSecret(transactionContext, aliceSig)
+	require.NoError(t, err)
+	require.EqualValues(t, secret.Value, defaultSecret.Value)
+}
+
+func TestNormalBehavior(t *testing.T) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeper(transactionContext)
+	require.NoError(t, err)
+
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(0)
+	_, secretByte := chaincodeStub.PutStateArgsForCall(1)
+
+	aliceSig := "Alice"
+	bobSig := "Bob"
+	eveSig := "Eve"
+	newSecret := "NewSecret"
+	newSecret2 := "SecretWithoutAlice"
+
+	chaincodeStub.GetStateReturnsOnCall(0, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(1, authSetByte, nil)
+	err = secretKeeper.AddUser(transactionContext, aliceSig, eveSig)
+	require.NoError(t, err)
+	_, authSetByte = chaincodeStub.PutStateArgsForCall(2)
+
+	chaincodeStub.GetStateReturnsOnCall(2, authSetByte, nil)
+	err = secretKeeper.LockSecret(transactionContext, eveSig, newSecret)
+	require.NoError(t, err)
+	_, secretByte = chaincodeStub.PutStateArgsForCall(3)
+
+	chaincodeStub.GetStateReturnsOnCall(3, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(4, secretByte, nil)
+	secret, err := secretKeeper.RevealSecret(transactionContext, aliceSig)
+	require.NoError(t, err)
+	require.EqualValues(t, secret.Value, newSecret)
+
+	chaincodeStub.GetStateReturnsOnCall(5, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(6, authSetByte, nil)
+	err = secretKeeper.RemoveUser(transactionContext, eveSig, aliceSig)
+	require.NoError(t, err)
+	_, authSetByte = chaincodeStub.PutStateArgsForCall(4)
+
+	chaincodeStub.GetStateReturnsOnCall(7, authSetByte, nil)
+	err = secretKeeper.LockSecret(transactionContext, bobSig, newSecret2)
+	require.NoError(t, err)
+	_, secretByte = chaincodeStub.PutStateArgsForCall(5)
+
+	chaincodeStub.GetStateReturnsOnCall(8, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(9, secretByte, nil)
+	secret, err = secretKeeper.RevealSecret(transactionContext, aliceSig)
+	require.EqualError(t, err, "User are not allowed to perform this action.")
+	require.Nil(t, secret)
+}
+
+func TestRollbackAttack(t *testing.T) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeper(transactionContext)
+	require.NoError(t, err)
+
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(0)
+	_, secretByte := chaincodeStub.PutStateArgsForCall(1)
+	oldauthSetByte := authSetByte
+
+	aliceSig := "Alice"
+	bobSig := "Bob"
+	eveSig := "Eve"
+	newSecret := "NewSecret"
+	newSecret2 := "SecretWithoutAlice"
+
+	chaincodeStub.GetStateReturnsOnCall(0, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(1, authSetByte, nil)
+	err = secretKeeper.AddUser(transactionContext, aliceSig, eveSig)
+	require.NoError(t, err)
+	_, authSetByte = chaincodeStub.PutStateArgsForCall(2)
+
+	chaincodeStub.GetStateReturnsOnCall(2, authSetByte, nil)
+	err = secretKeeper.LockSecret(transactionContext, eveSig, newSecret)
+	require.NoError(t, err)
+	_, secretByte = chaincodeStub.PutStateArgsForCall(3)
+
+	chaincodeStub.GetStateReturnsOnCall(3, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(4, secretByte, nil)
+	secret, err := secretKeeper.RevealSecret(transactionContext, aliceSig)
+	require.NoError(t, err)
+	require.EqualValues(t, secret.Value, newSecret)
+
+	chaincodeStub.GetStateReturnsOnCall(5, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(6, authSetByte, nil)
+	err = secretKeeper.RemoveUser(transactionContext, eveSig, aliceSig)
+	require.NoError(t, err)
+
+	_, authSetByte = chaincodeStub.PutStateArgsForCall(4)
+
+	chaincodeStub.GetStateReturnsOnCall(7, authSetByte, nil)
+	err = secretKeeper.LockSecret(transactionContext, bobSig, newSecret2)
+	require.NoError(t, err)
+	_, secretByte = chaincodeStub.PutStateArgsForCall(5)
+
+	// Simulate rollback attack here
+	chaincodeStub.GetStateReturnsOnCall(8, oldauthSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(9, secretByte, nil)
+	secret, err = secretKeeper.RevealSecret(transactionContext, aliceSig)
+	require.NoError(t, err)
+	require.EqualValues(t, secret.Value, newSecret2)
+}

--- a/samples/chaincode/secret-keeper-go/main.go
+++ b/samples/chaincode/secret-keeper-go/main.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+	fpc "github.com/hyperledger/fabric-private-chaincode/ecc_go/chaincode"
+	"github.com/hyperledger/fabric-private-chaincode/samples/chaincode/secret-keeper-go/chaincode"
+)
+
+func main() {
+
+	ccid := os.Getenv("CHAINCODE_PKG_ID")
+	addr := os.Getenv("CHAINCODE_SERVER_ADDRESS")
+
+	// create chaincode
+	secretChaincode, _ := contractapi.NewChaincode(&chaincode.SecretKeeper{})
+	chaincode := fpc.NewPrivateChaincode(secretChaincode)
+
+	// start chaincode as a service
+	server := &shim.ChaincodeServer{
+		CCID:    ccid,
+		Address: addr,
+		CC:      chaincode,
+		TLSProps: shim.TLSProperties{
+			Disabled: true, // just for testing good enough
+		},
+	}
+
+	if err := server.Start(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Create a new application for rollback attack scenario, namely Secret Keeper


**Special notes for your reviewer**:
Secret Keeper has 5 functions.
InitSecretKeeper: 
- This function will initialize the key "AUTH_LIST_KEY" with value ["Alice", "Bob"] and key "SECRET_KEY" with value "DefaultSecret".
- This function should only be called once when the application started. 
- Of course a malicious user can call this function to reset the value, but this we will assume this is not what an attacker would want to achieve.

RevealSecret:
- This function allow users that in the Authlist ("AUTH_LIST_KEY") able to reveal the value of secret stored under key "SECRET_KEY".

LockSecret:
- This function allow users that in the Authlist ("AUTH_LIST_KEY") able to store a new value of secret under key "SECRET_KEY". 
- The old value will be replaced.

AddUser:
- This function allow users that in the Authlist ("AUTH_LIST_KEY") able to add a new user to the Authlist.
- Then the new user can now perform the following four functions (RevealSecret, LockSecret, AddUser, RemoveUser)

RemoveUser:
- This function allow users that in the Authlist ("AUTH_LIST_KEY") able to add remove an existing user off the Authlist.
- Then the removed user can no longer able to perform the following four functions (RevealSecret, LockSecret, AddUser, RemoveUser)

Example using fpc-simle-client:
```
./fpcclient invoke initSecretKeeper
./fpcclient query revealSecret Alice
./fpcclient invoke lockSecret Bob NewSecret
./fpcclient query revealSecret Alice
./fpcclient invoke removeUser Alice Bob
./fpcclient query revealSecret Alice
./fpcclient query revealSecret Bob  // (will failed)
./fpcclient invoke addUser Alice Bob
./fpcclient query revealSecret Bob // (will success)
```
