### PR TITLE
add secret-keeper-ext

### DIFF
--- a/samples/chaincode/secret-keeper-ext/.gitignore
+++ b/samples/chaincode/secret-keeper-ext/.gitignore
@@ -1,0 +1,7 @@
+ecc
+ecc-bundle
+enclave.json
+private.pem
+public.pem
+mrenclave
+details.env

--- a/samples/chaincode/secret-keeper-ext/Makefile
+++ b/samples/chaincode/secret-keeper-ext/Makefile
@@ -1,0 +1,9 @@
+# Copyright 2019 Intel Corporation
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TOP = ../../..
+include $(TOP)/ecc_go/build.mk
+
+CC_NAME ?= fpc-secret-keeper-ext

--- a/samples/chaincode/secret-keeper-ext/chaincode/secret-keeper-ext.go
+++ b/samples/chaincode/secret-keeper-ext/chaincode/secret-keeper-ext.go
@@ -1,0 +1,296 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+	"github.com/pkg/errors"
+)
+
+const OK = "OK"
+const ADMIN_LIST_KEY = "ADMIN_LIST_KEY"
+const DEFAULT_KEY = "DEFAULT"
+const POSTFIX_AUTH_LIST = "|AUTH_LIST_KEY"
+const POSTFIX_SECRET = "|SECRET_KEY"
+
+type SecretKeeper struct {
+	contractapi.Contract
+}
+
+type AuthSet struct {
+	Pubkey map[string]struct{}
+}
+
+func (a *AuthSet) ExportToString() string {
+	authlist := []string{}
+	for key := range a.Pubkey {
+		authlist = append(authlist, key)
+	}
+	sort.Strings(authlist)
+	return strings.Join(authlist, "|")
+}
+
+func (a *AuthSet) ImportFromString(pubkeys string) error {
+	pubkeylist := strings.Split(pubkeys, "|")
+	for _, pubkey := range pubkeylist {
+		a.Pubkey[pubkey] = struct{}{}
+	}
+	return nil
+}
+
+type Secret struct {
+	Value string `json:Value`
+}
+
+func (t *SecretKeeper) InitSecretKeeperExt(ctx contractapi.TransactionContextInterface) error {
+	// init adminSet
+	adminSet := make(map[string]struct{})
+	adminSet["Alice"] = struct{}{}
+	adminSet["Bob"] = struct{}{}
+	authSet := AuthSet{
+		Pubkey: adminSet,
+	}
+	authSetJson, err := json.Marshal(authSet)
+	if err != nil {
+		return err
+	}
+	err = ctx.GetStub().PutState(ADMIN_LIST_KEY, authSetJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", ADMIN_LIST_KEY, err)
+	}
+
+	return createSecret(ctx, authSet.ExportToString(), DEFAULT_KEY, "DefaultSecret")
+}
+
+func (t *SecretKeeper) AddAdmin(ctx contractapi.TransactionContextInterface, sig string, pubkey string) error {
+	// check if the user allow to update admin list.
+	valid, err := VerifySig(ctx, sig, ADMIN_LIST_KEY)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return errors.New("VerifySig failed, User are not Admin")
+	}
+
+	// update the value
+	return updateAuth(ctx, pubkey, ADMIN_LIST_KEY, true)
+}
+
+func (t *SecretKeeper) RemoveAdmin(ctx contractapi.TransactionContextInterface, sig string, pubkey string) error {
+	// check if the user allow to update admin list
+	valid, err := VerifySig(ctx, sig, ADMIN_LIST_KEY)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return errors.New("VerifySig failed, User are not Admin")
+	}
+
+	// update the value
+	return updateAuth(ctx, pubkey, ADMIN_LIST_KEY, false)
+}
+
+func (t *SecretKeeper) CreateSecret(ctx contractapi.TransactionContextInterface, sig, pubkeys, key, value string) error {
+	// check if the user allow to create secret
+	valid, err := VerifySig(ctx, sig, ADMIN_LIST_KEY)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return errors.New("VerifySig failed, User are not Admin")
+	}
+
+	// check if the authKey and secretKey are not created
+	authKey := key + POSTFIX_AUTH_LIST
+	secretKey := key + POSTFIX_SECRET
+
+	authJson, err := ctx.GetStub().GetState(authKey)
+	if err != nil {
+		return fmt.Errorf("failed to read from world state: %v", err)
+	}
+	if authJson != nil {
+		return fmt.Errorf("the secret %s already existed", key)
+	}
+	secretJson, err := ctx.GetStub().GetState(secretKey)
+	if err != nil {
+		return fmt.Errorf("failed to read from world state: %v", err)
+	}
+	if secretJson != nil {
+		return fmt.Errorf("the secret %s already existed", key)
+	}
+	return createSecret(ctx, pubkeys, key, value)
+}
+
+func (t *SecretKeeper) AddUser(ctx contractapi.TransactionContextInterface, sig string, pubkey string, key string) error {
+	authKey := key + POSTFIX_AUTH_LIST
+
+	// check if the user allow to update authSet
+	valid, err := VerifySig(ctx, sig, authKey)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return errors.New("VerifySig failed, User are not allowed to perform this action")
+	}
+
+	// update the value
+	return updateAuth(ctx, pubkey, authKey, true)
+}
+
+func (t *SecretKeeper) RemoveUser(ctx contractapi.TransactionContextInterface, sig string, pubkey string, key string) error {
+	authKey := key + POSTFIX_AUTH_LIST
+
+	// check if the user allow to update authSet
+	valid, err := VerifySig(ctx, sig, authKey)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return errors.New("VerifySig failed, User are not allowed to perform this action")
+	}
+
+	// update the value
+	return updateAuth(ctx, pubkey, authKey, false)
+}
+
+func (t *SecretKeeper) LockSecret(ctx contractapi.TransactionContextInterface, sig string, key string, value string) error {
+	authKey := key + POSTFIX_AUTH_LIST
+	secretKey := key + POSTFIX_SECRET
+
+	// check if the user allow to update secret
+	valid, err := VerifySig(ctx, sig, authKey)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return errors.New("VerifySig failed, User are not allowed to perform this action")
+	}
+
+	// update the value
+	return updateSecret(ctx, secretKey, value)
+}
+
+func (t *SecretKeeper) RevealSecret(ctx contractapi.TransactionContextInterface, sig string, key string) (*Secret, error) {
+	authKey := key + POSTFIX_AUTH_LIST
+	secretKey := key + POSTFIX_SECRET
+
+	// check if the user allow to view the secret.
+	valid, err := VerifySig(ctx, sig, authKey)
+	if err != nil {
+		return nil, err
+	}
+	if !valid {
+		return nil, errors.New("VerifySig failed, User are not allowed to perform this action")
+	}
+
+	// reveal secret
+	secretJson, err := ctx.GetStub().GetState(secretKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from world state: %v", err)
+	}
+	if secretJson == nil {
+		return nil, fmt.Errorf("the asset %s does not exist", secretKey)
+	}
+	var secret Secret
+	err = json.Unmarshal(secretJson, &secret)
+	if err != nil {
+		return nil, err
+	}
+	return &secret, nil
+}
+
+func createSecret(ctx contractapi.TransactionContextInterface, pubkeys, key, value string) error {
+	authKey := key + POSTFIX_AUTH_LIST
+	secretKey := key + POSTFIX_SECRET
+
+	// extract public keys and save pubkeys
+	pubkeySet := AuthSet{
+		Pubkey: map[string]struct{}{},
+	}
+	pubkeySet.ImportFromString(pubkeys)
+	pubkeySetJson, err := json.Marshal(pubkeySet)
+	if err != nil {
+		return err
+	}
+	err = ctx.GetStub().PutState(authKey, pubkeySetJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", authKey, err)
+	}
+
+	// extract and save value
+	return updateSecret(ctx, secretKey, value)
+}
+
+func updateAuth(ctx contractapi.TransactionContextInterface, pubkey string, key string, addElseDel bool) error {
+	authSet, _ := GetAuthList(ctx, key)
+
+	if addElseDel {
+		authSet.Pubkey[pubkey] = struct{}{}
+	} else {
+		delete(authSet.Pubkey, pubkey)
+	}
+
+	authSetJson, err := json.Marshal(authSet)
+	if err != nil {
+		return err
+	}
+	err = ctx.GetStub().PutState(key, authSetJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", key, err)
+	}
+	return nil
+}
+
+func updateSecret(ctx contractapi.TransactionContextInterface, key string, value string) error {
+	newSecret := Secret{
+		Value: value,
+	}
+	newSecretJson, err := json.Marshal(newSecret)
+	if err != nil {
+		return err
+	}
+	err = ctx.GetStub().PutState(key, newSecretJson)
+	if err != nil {
+		return fmt.Errorf("failed to put %s to world state. %v", key, err)
+	}
+	return nil
+}
+
+func GetAuthList(ctx contractapi.TransactionContextInterface, key string) (*AuthSet, error) {
+	authSetJson, err := ctx.GetStub().GetState(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read from world state: %v", err)
+	}
+	if authSetJson == nil {
+		return nil, fmt.Errorf("the asset %s does not exist", key)
+	}
+
+	var authSet AuthSet
+	err = json.Unmarshal(authSetJson, &authSet)
+	if err != nil {
+		return nil, err
+	}
+	return &authSet, nil
+}
+
+func VerifySig(ctx contractapi.TransactionContextInterface, sig string, key string) (bool, error) {
+	authSet, err := GetAuthList(ctx, key)
+	if err != nil {
+		return false, err
+	}
+
+	if _, exist := authSet.Pubkey[sig]; exist {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/samples/chaincode/secret-keeper-ext/chaincode/secret-keeper-ext_test.go
+++ b/samples/chaincode/secret-keeper-ext/chaincode/secret-keeper-ext_test.go
@@ -25,6 +25,20 @@ func Setup(t *testing.T) (SecretKeeper, *fakes.ChaincodeStub, *fakes.Transaction
 	return secretKeeper, chaincodeStub, transactionContext, adminSetByte, authSetByte, secretByte
 }
 
+func TestInit(t *testing.T) {
+	_, _, _, _, authSetByte, secretByte := Setup(t)
+
+	var recvAuth AuthSet
+	err := json.Unmarshal(authSetByte, &recvAuth)
+	require.NoError(t, err)
+	require.Equal(t, recvAuth.ExportToString(), "Alice|Bob")
+
+	var recvSecretValue Secret
+	err = json.Unmarshal(secretByte, &recvSecretValue)
+	require.NoError(t, err)
+	require.Equal(t, recvSecretValue.Value, "DefaultSecret")
+}
+
 func TestWrongSignature(t *testing.T) {
 	secretKeeper, chaincodeStub, transactionContext, adminSetByte, _, _ := Setup(t)
 

--- a/samples/chaincode/secret-keeper-ext/chaincode/secret-keeper-ext_test.go
+++ b/samples/chaincode/secret-keeper-ext/chaincode/secret-keeper-ext_test.go
@@ -1,0 +1,303 @@
+package chaincode
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-private-chaincode/ercc/registry/fakes"
+	"github.com/stretchr/testify/require"
+)
+
+func Setup(t *testing.T) (SecretKeeper, *fakes.ChaincodeStub, *fakes.TransactionContext, []byte, []byte, []byte) {
+	chaincodeStub := &fakes.ChaincodeStub{}
+	transactionContext := &fakes.TransactionContext{}
+	transactionContext.GetStubReturns(chaincodeStub)
+
+	secretKeeper := SecretKeeper{}
+	err := secretKeeper.InitSecretKeeperExt(transactionContext)
+	require.NoError(t, err)
+
+	_, adminSetByte := chaincodeStub.PutStateArgsForCall(0)
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(1) // get default secret authlist
+	_, secretByte := chaincodeStub.PutStateArgsForCall(2)  // get default secret value
+
+	return secretKeeper, chaincodeStub, transactionContext, adminSetByte, authSetByte, secretByte
+}
+
+func TestWrongSignature(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, adminSetByte, _, _ := Setup(t)
+
+	chaincodeStub.GetStateReturns(adminSetByte, nil)
+
+	falseSig := "falseSignature"
+	fakeSecret := "fakeSecret"
+	fakeKey := "fakeKey"
+
+	err := secretKeeper.AddAdmin(transactionContext, falseSig, falseSig)
+	require.EqualError(t, err, "VerifySig failed, User are not Admin")
+
+	err = secretKeeper.RemoveAdmin(transactionContext, falseSig, falseSig)
+	require.EqualError(t, err, "VerifySig failed, User are not Admin")
+
+	err = secretKeeper.CreateSecret(transactionContext, falseSig, falseSig, fakeKey, fakeSecret)
+	require.EqualError(t, err, "VerifySig failed, User are not Admin")
+
+	err = secretKeeper.AddUser(transactionContext, falseSig, falseSig, fakeKey)
+	require.EqualError(t, err, "VerifySig failed, User are not allowed to perform this action")
+
+	err = secretKeeper.RemoveUser(transactionContext, falseSig, falseSig, fakeKey)
+	require.EqualError(t, err, "VerifySig failed, User are not allowed to perform this action")
+
+	err = secretKeeper.LockSecret(transactionContext, falseSig, fakeKey, fakeSecret)
+	require.EqualError(t, err, "VerifySig failed, User are not allowed to perform this action")
+
+	secret, err := secretKeeper.RevealSecret(transactionContext, falseSig, fakeKey)
+	require.EqualError(t, err, "VerifySig failed, User are not allowed to perform this action")
+	require.Nil(t, secret)
+}
+
+func TestAddAdmin(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, adminSetByte, _, _ := Setup(t)
+	chaincodeStub.GetStateReturns(adminSetByte, nil)
+
+	aliceSig := "Alice"
+	evePubKey := "Eve"
+
+	// check if adminlist not contains eve
+	var authSet AuthSet
+	err := json.Unmarshal(adminSetByte, &authSet)
+	require.NoError(t, err)
+	_, exist := authSet.Pubkey[evePubKey]
+	require.False(t, exist)
+
+	err = secretKeeper.AddAdmin(transactionContext, aliceSig, evePubKey)
+	require.NoError(t, err)
+
+	// check if adminlist contains eve.
+	_, authSetByte2 := chaincodeStub.PutStateArgsForCall(3)
+	var authSet2 AuthSet
+	err = json.Unmarshal(authSetByte2, &authSet2)
+	require.NoError(t, err)
+	_, exist = authSet2.Pubkey[evePubKey]
+	require.True(t, exist)
+}
+
+func TestRemoveAdmin(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, adminSetByte, _, _ := Setup(t)
+	chaincodeStub.GetStateReturns(adminSetByte, nil)
+
+	aliceSig := "Alice"
+	bobPubKey := "Bob"
+
+	// check if adminlist contains bob.
+	var authSet AuthSet
+	err := json.Unmarshal(adminSetByte, &authSet)
+	require.NoError(t, err)
+	_, exist := authSet.Pubkey[bobPubKey]
+	require.True(t, exist)
+
+	err = secretKeeper.RemoveAdmin(transactionContext, aliceSig, bobPubKey)
+	require.NoError(t, err)
+
+	// check if adminlist doesn't contain bob anymore.
+	_, authSetByte2 := chaincodeStub.PutStateArgsForCall(3)
+	var authSet2 AuthSet
+	err = json.Unmarshal(authSetByte2, &authSet2)
+	require.NoError(t, err)
+	_, exist = authSet2.Pubkey[bobPubKey]
+	require.False(t, exist)
+}
+
+func TestAddUser(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, _, authSetByte, _ := Setup(t)
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	aliceSig := "Alice"
+	evePubKey := "Eve"
+	defaultKey := DEFAULT_KEY
+
+	// check if authlist not contains eve
+	var authSet AuthSet
+	err := json.Unmarshal(authSetByte, &authSet)
+	require.NoError(t, err)
+	_, exist := authSet.Pubkey[evePubKey]
+	require.False(t, exist)
+
+	err = secretKeeper.AddUser(transactionContext, aliceSig, evePubKey, defaultKey)
+	require.NoError(t, err)
+
+	// check if authlist contains eve.
+	_, authSetByte2 := chaincodeStub.PutStateArgsForCall(3)
+	var authSet2 AuthSet
+	err = json.Unmarshal(authSetByte2, &authSet2)
+	require.NoError(t, err)
+	_, exist = authSet2.Pubkey[evePubKey]
+	require.True(t, exist)
+}
+
+func TestRemoveUser(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, _, authSetByte, _ := Setup(t)
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	aliceSig := "Alice"
+	bobPubKey := "Bob"
+	defaultKey := DEFAULT_KEY
+
+	// check if authlist contains bob.
+	var authSet AuthSet
+	err := json.Unmarshal(authSetByte, &authSet)
+	require.NoError(t, err)
+	_, exist := authSet.Pubkey[bobPubKey]
+	require.True(t, exist)
+
+	err = secretKeeper.RemoveUser(transactionContext, aliceSig, bobPubKey, defaultKey)
+	require.NoError(t, err)
+
+	// check if authlist doesn't contain bob anymore.
+	_, authSetByte2 := chaincodeStub.PutStateArgsForCall(3)
+	var authSet2 AuthSet
+	err = json.Unmarshal(authSetByte2, &authSet2)
+	require.NoError(t, err)
+	_, exist = authSet2.Pubkey[bobPubKey]
+	require.False(t, exist)
+}
+
+func TestCreateSecret(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, adminSetByte, _, _ := Setup(t)
+	chaincodeStub.GetStateReturnsOnCall(0, adminSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(1, nil, nil)
+	chaincodeStub.GetStateReturnsOnCall(2, nil, nil)
+
+	aliceSig := "Alice"
+	newSecretKey := "newSecret"
+	newSecretValue := "newValue"
+	pubkeys := &AuthSet{
+		Pubkey: map[string]struct{}{},
+	}
+	pubkeys.Pubkey["Alice"] = struct{}{}
+	pubkeys.Pubkey["Bob"] = struct{}{}
+
+	// first time will create success
+	err := secretKeeper.CreateSecret(transactionContext, aliceSig, pubkeys.ExportToString(), newSecretKey, newSecretValue)
+	require.NoError(t, err)
+
+	_, authSetByte2 := chaincodeStub.PutStateArgsForCall(3)
+	_, secretByte2 := chaincodeStub.PutStateArgsForCall(4)
+
+	// check value
+	var recvAuth AuthSet
+	err = json.Unmarshal(authSetByte2, &recvAuth)
+	require.NoError(t, err)
+	require.Equal(t, recvAuth.ExportToString(), pubkeys.ExportToString())
+
+	var recvSecretValue Secret
+	err = json.Unmarshal(secretByte2, &recvSecretValue)
+	require.NoError(t, err)
+
+	// second time will create failed
+	chaincodeStub.GetStateReturnsOnCall(3, authSetByte2, nil)
+	chaincodeStub.GetStateReturnsOnCall(4, secretByte2, nil)
+	err = secretKeeper.CreateSecret(transactionContext, aliceSig, pubkeys.ExportToString(), newSecretKey, newSecretValue)
+	require.EqualError(t, err, fmt.Sprintf("the secret %s already existed", newSecretKey))
+
+}
+
+func TestLockSecret(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, _, authSetByte, _ := Setup(t)
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	aliceSig := "Alice"
+	defaultKey := DEFAULT_KEY
+	newSecret := "newSecret"
+
+	err := secretKeeper.LockSecret(transactionContext, aliceSig, defaultKey, newSecret)
+	require.NoError(t, err)
+
+	// check secret key value.
+	_, secretByte := chaincodeStub.PutStateArgsForCall(3)
+	var secret Secret
+	err = json.Unmarshal(secretByte, &secret)
+	require.NoError(t, err)
+	require.EqualValues(t, secret.Value, newSecret)
+}
+
+func TestRevealSecret(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, _, authSetByte, defaultSecretByte := Setup(t)
+	chaincodeStub.GetStateReturns(authSetByte, nil)
+
+	aliceSig := "Alice"
+	defaultKey := DEFAULT_KEY
+
+	var defaultSecret Secret
+	err := json.Unmarshal(defaultSecretByte, &defaultSecret)
+	require.NoError(t, err)
+
+	// check the return value equal with the secret in test.
+	chaincodeStub.GetStateReturnsOnCall(0, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(1, defaultSecretByte, nil)
+	secret, err := secretKeeper.RevealSecret(transactionContext, aliceSig, defaultKey)
+	require.NoError(t, err)
+	require.EqualValues(t, secret.Value, defaultSecret.Value)
+}
+
+func TestNormalBehavior(t *testing.T) {
+	secretKeeper, chaincodeStub, transactionContext, adminSetByte, _, _ := Setup(t)
+
+	aliceSig := "Alice"
+	bobSig := "Bob"
+	eveSig := "Eve"
+
+	// add eve to admin
+	chaincodeStub.GetStateReturnsOnCall(0, adminSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(1, adminSetByte, nil)
+	err := secretKeeper.AddAdmin(transactionContext, aliceSig, eveSig)
+	require.NoError(t, err)
+	_, adminSetByte = chaincodeStub.PutStateArgsForCall(3)
+
+	// eve create newsecret
+	newSecretKey := "newSecretKey"
+	newSecretValue := "newSecretValue~v1"
+	chaincodeStub.GetStateReturnsOnCall(2, adminSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(3, nil, nil)
+	chaincodeStub.GetStateReturnsOnCall(4, nil, nil)
+	err = secretKeeper.CreateSecret(transactionContext, eveSig, bobSig+"|"+eveSig, newSecretKey, newSecretValue)
+	require.NoError(t, err)
+	_, authSetByte := chaincodeStub.PutStateArgsForCall(4)
+	_, secretByte := chaincodeStub.PutStateArgsForCall(5)
+
+	// bob able to reveal newsecret
+	chaincodeStub.GetStateReturnsOnCall(5, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(6, secretByte, nil)
+	revSecret, err := secretKeeper.RevealSecret(transactionContext, bobSig, newSecretKey)
+	require.NoError(t, err)
+	require.Equal(t, revSecret.Value, newSecretValue)
+
+	// bob add alice to newsecret
+	chaincodeStub.GetStateReturnsOnCall(7, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(8, authSetByte, nil)
+	err = secretKeeper.AddUser(transactionContext, bobSig, aliceSig, newSecretKey)
+	require.NoError(t, err)
+	_, authSetByte = chaincodeStub.PutStateArgsForCall(6)
+
+	// alice remove bob from newsecret
+	chaincodeStub.GetStateReturnsOnCall(9, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(10, authSetByte, nil)
+	err = secretKeeper.RemoveUser(transactionContext, aliceSig, bobSig, newSecretKey)
+	require.NoError(t, err)
+	_, authSetByte = chaincodeStub.PutStateArgsForCall(7)
+
+	// eve lock newsecret
+	newSecretValue = "newSecretValue~v2"
+	chaincodeStub.GetStateReturnsOnCall(11, authSetByte, nil)
+	err = secretKeeper.LockSecret(transactionContext, eveSig, newSecretKey, newSecretValue)
+	require.NoError(t, err)
+	_, secretByte = chaincodeStub.PutStateArgsForCall(8)
+
+	// bob not able to reveal newsecret
+	chaincodeStub.GetStateReturnsOnCall(12, authSetByte, nil)
+	chaincodeStub.GetStateReturnsOnCall(13, secretByte, nil)
+	revSecret, err = secretKeeper.RevealSecret(transactionContext, bobSig, newSecretKey)
+	require.EqualError(t, err, "VerifySig failed, User are not allowed to perform this action")
+	require.Nil(t, revSecret)
+}

--- a/samples/chaincode/secret-keeper-ext/main.go
+++ b/samples/chaincode/secret-keeper-ext/main.go
@@ -1,0 +1,42 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+	fpc "github.com/hyperledger/fabric-private-chaincode/ecc_go/chaincode"
+	"github.com/hyperledger/fabric-private-chaincode/samples/chaincode/secret-keeper-ext/chaincode"
+)
+
+func main() {
+
+	ccid := os.Getenv("CHAINCODE_PKG_ID")
+	addr := os.Getenv("CHAINCODE_SERVER_ADDRESS")
+
+	// create chaincode
+	secretChaincode, _ := contractapi.NewChaincode(&chaincode.SecretKeeper{})
+	chaincode := fpc.NewPrivateChaincode(secretChaincode)
+	// chaincode := fpc.NewSkvsChaincode(secretChaincode)
+
+	// start chaincode as a service
+	server := &shim.ChaincodeServer{
+		CCID:    ccid,
+		Address: addr,
+		CC:      chaincode,
+		TLSProps: shim.TLSProperties{
+			Disabled: true, // just for testing good enough
+		},
+	}
+
+	if err := server.Start(); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
What this PR does / why we need it:
Create a new extension for secret-keeper to support storing multiple key and value.

Special notes for your reviewer:
Secret Keeper has 8 functions.

InitSecretKeeperExt():
- This function will initialize the key "ADMIN_LIST_KEY" with value ["Alice", "Bob"] and create a default secret "DEFAULT" with value "DefaultSecret".
- This function should only be called once when the application started.
- Of course a malicious user can call this function to reset the value, but this we will assume this is not what an attacker would want to achieve.

AddAdmin(sign, pubkey):
- This function allow the users who has their public key (sign) in the Adminlist ("ADMIN_LIST_KEY") able to add a new admin's public key (pubkey) to the Adminlist. 
- Then the new user can now execute the following three functions (AddAdmin, RemoveAdmin, CreateSecret)

RemoveAdmin(sign, pubkey):
- This function allow the users who has their public key (sign) in the Adminlist ("ADMIN_LIST_KEY") able to remove an existing user's public key (pubkey) off the Authlist.
- Then the removed user can no longer able to execute the following three functions (AddAdmin, RemoveAdmin, CreateSecret)

CreateSecret(sign, pubkeys, key, value):
- This function allow the admin (sign) to create a new secret and added all the allows user (pubkeys) to (key+"|AUTH_LIST_KEY") and add the secret (value) to (key+"|AUTH_LIST_KEY").  
- The users that assign to the secret are now able to execute the following four functions (RevealSecret, LockSecret, AddUser, RemoveUser)

AddUser(sig, pubkey, key):
- This function allow users that in the Authlist (key+"|AUTH_LIST_KEY") able to add a new user to the secret key.
- Then the new user can now execute the following four functions (RevealSecret, LockSecret, AddUser, RemoveUser)

RemoveUser(sig, pubkey, key):
- This function allow users that in the Authlist (key+"|AUTH_LIST_KEY") able to remove an existing user off the Authlist.
- Then the removed user can no longer able to execute the following four functions (RevealSecret, LockSecret, AddUser, RemoveUser)

RevealSecret(sig, key):
- This function allow users that in the Authlist (key+"|AUTH_LIST_KEY") able to reveal the value of secret stored under (key+"|SECRET_KEY").

LockSecret(sig, key):
- This function allow users that in the Authlist (key+"|AUTH_LIST_KEY") able to store a new value of secret under (key+"|SECRET_KEY").
- The old value will be replaced.

Example using fpc-simple-client:
```
./fpcclient invoke initSecretKeeperExt
./fpcclient query revealSecret Alice DEFAULT
./fpcclient invoke lockSecret Bob DEFAULT NewSecret
./fpcclient query revealSecret Alice DEFAULT
./fpcclient invoke addAdmin Alice Eve
./fpcclient invoke createSecret Eve "Eve|Alice" EveSecret EveSecretValue
./fpcclient query revealSecret Alice EveSecret
./fpcclient query revealSecret Bob EveSecret // (will failed)
./fpcclient invoke addUser Eve Bob EveSecret
./fpcclient query revealSecret Bob EveSecret
./fpcclient invoke removeUser Alice Eve EveSecret
./fpcclient invoke lockSecret Alice EveSecret SecretNoMore
./fpcclient query revealSecret Bob EveSecret
./fpcclient query revealSecret Eve EveSecret // (will failed)
```